### PR TITLE
Disable Save when segue from Board Selection to Choice Selection

### DIFF
--- a/TeamJesseAndAlex/MultipleChoiceViewController.swift
+++ b/TeamJesseAndAlex/MultipleChoiceViewController.swift
@@ -17,9 +17,17 @@ class MultipleChoiceViewController: UIViewController {
     
     @IBOutlet weak var saveBoardButton: UIBarButtonItem!
     var board: Board?
+    var saveDisabled: Bool?
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        if (saveDisabled != nil && saveDisabled!)
+        {
+            self.saveBoardButton.title = ""
+            self.saveBoardButton.isEnabled = false
+        }
+        
         
         NotificationCenter.default.addObserver(forName: Notification.Name("choiceConfigured"), object: nil, queue: .main){ notification in
             let choice = notification.userInfo?["choice"] as! Choice

--- a/TeamJesseAndAlex/SavedBoardsTableViewController.swift
+++ b/TeamJesseAndAlex/SavedBoardsTableViewController.swift
@@ -63,6 +63,7 @@ class SavedBoardsTableViewController: UITableViewController {
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         (segue.destination as! MultipleChoiceViewController).board = sender as! Board
+        (segue.destination as! MultipleChoiceViewController).saveDisabled = true as! Bool
     }
     
 


### PR DESCRIPTION
added an (optional) member variable to MultipleChoiceViewController class as a flag for segue

Variable is assigned to 'true' in segue from SavedBoards table to MultipleChoice view. Conditional block matching the flag disables the Save button and empties the button's text   (could not find a good way to simply _hide_ the button)